### PR TITLE
(feat) front-end auth skeleton setup

### DIFF
--- a/client/app.jsx
+++ b/client/app.jsx
@@ -1,4 +1,3 @@
-import * as action from './services/actionConstants.jsx';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import Footer from './containers/footer.jsx';
@@ -6,10 +5,10 @@ import Header from './containers/header.jsx';
 import Content from './containers/content.jsx';
 import LeftNav from './containers/leftNav.jsx';
 import RightNav from './containers/rightNav.jsx';
+import Login from './components/login.jsx';
 
 class App extends Component {
-
-  render() {
+  composedApp() {
     return (
       <div id="composedApp">
         <Header />
@@ -23,10 +22,16 @@ class App extends Component {
     );
   }
 
+  render() {
+    return this.props.token ? this.composedApp() : <Login/>;
+  }
+
 }
 
-let select = function( state ){
-  return { token: state.token };
+let select = (state) => {
+  return { 
+    token: state.data.auth.token
+  };
 };
 
-export default connect( select )( App );
+export default connect(select)(App);

--- a/client/components/home.jsx
+++ b/client/components/home.jsx
@@ -1,5 +1,5 @@
 import React, {Component} from 'react';
-import { connect } from 'react-redux';
+import {connect} from 'react-redux';
 import actions from '../services/actionCreators.jsx';
 
 class Home extends Component {
@@ -12,10 +12,10 @@ class Home extends Component {
   }
 }
 
-const select = ( state ) => {
+const select = (state) => {
   return {
 
   };
 };
 
-export default connect( select )( Home );
+export default connect(select)(Home);

--- a/client/components/login.jsx
+++ b/client/components/login.jsx
@@ -1,0 +1,29 @@
+import React, {Component} from 'react';
+import {connect} from 'react-redux';
+import actions from '../services/actionCreators.jsx';
+
+class Login extends Component{
+  loginClick() {
+    let ubox = document.getElementById('usernameInput');
+    let pbox = document.getElementById('passwordInput');
+    this.props.dispatch(actions.logIn(ubox.value, pbox.value));
+    ubox.value = pbox.value = '';
+  }
+  render() {
+    return (
+      <div>
+        <input type="textarea" id="usernameInput" paceholder="email"/>
+        <input type="password" id="passwordInput"paceholder="password"/>
+        <div className='clickable' onClick={this.loginClick.bind(this)}>Login</div>
+      </div>
+    );
+  }
+
+};
+
+const select = (state) => {
+  return {
+  };
+};
+
+export default connect(select)(Login);

--- a/client/containers/content.jsx
+++ b/client/containers/content.jsx
@@ -4,6 +4,7 @@ import store from '../services/store.jsx';
 import Home from '../components/home.jsx';
 import Trade from '../components/trade.jsx';
 import Draft from '../components/draft.jsx';
+import Login from '../components/login.jsx';
 
 class Content extends Component {
 
@@ -25,7 +26,7 @@ class Content extends Component {
       <div id='center'>
         {this.renderMain()}
       </div> 
-    )
+    );
   }
 
 };

--- a/client/containers/leftNav.jsx
+++ b/client/containers/leftNav.jsx
@@ -15,7 +15,7 @@ class LeftNav extends Component {
     });
   }
   render() {
-    const tabs = ['HOME','DRAFT','TRADE']
+    const tabs = ['HOME', 'DRAFT', 'TRADE', 'LOGOUT']
     return (
       <div id="left">
         <ul>
@@ -25,6 +25,9 @@ class LeftNav extends Component {
     );
   }
   navigate(tab) {
+    if(tab==='LOGOUT'){
+      return this.props.dispatch(actions.logOut());
+    }
     this.props.dispatch(actions.navigateTo(tab));
   }
   

--- a/client/reducers/dataReducer.js
+++ b/client/reducers/dataReducer.js
@@ -1,27 +1,27 @@
 import {combineReducers} from 'redux';
 
-let leagueReducer = (state = {}, action) => {
+const leagueReducer = (state = {}, action) => {
   switch(action.type) {
     default:
       return state;
   }
 };
 
-let charactersReducer = (state = [], action) => {
+const charactersReducer = (state = [], action) => {
   switch(action.type){
     default:
       return state;
   }
 };
 
-let eventsReducer = (state = [], action) => {
+const eventsReducer = (state = [], action) => {
   switch(action.type) {
     default:
       return state;
   }
 };
 
-let userReducer = (state = {}, action) => {
+const userReducer = (state = {}, action) => {
   switch(action.type){
     case 'UPDATE_USER_SUCCESS':
       console.log(action);
@@ -37,9 +37,25 @@ let userReducer = (state = {}, action) => {
   }
 };
 
+const authReducer = (state = {token:'devModeStartLoggedIn'}, action) => {
+  switch(action.type){
+    case 'LOGIN_SUCCESS':
+      return Object.assign({}, state, {token:action.payload.token, self:action.payload.user});
+    case 'LOGIN_FAILURE':
+      // login attempt/failure logic here, do something if many failed attempts
+      return state;
+    case 'LOGOUT':
+      // also destroy cookie?
+      return Object.assign({},state,{token:'',self:{}})
+    default:
+      return state;
+  }
+};
+
 export default combineReducers({
   user: userReducer,
   characters: charactersReducer,
   league: leagueReducer,
   events: eventsReducer,
+  auth: authReducer
 });

--- a/client/services/actionConstants.jsx
+++ b/client/services/actionConstants.jsx
@@ -5,6 +5,7 @@ export const LOGIN_SUCCESS = 'LOGIN_SUCCESS';
 export const LOGIN_FAILURE = 'LOGIN_FAILURE';
 export const SIGNUP_SUCCESS = 'SIGNUP_SUCCESS';
 export const SIGNUP_FAILURE = 'SIGNUP_FAILURE';
+export const LOGOUT = 'LOGOUT';
 
 // user
 export const UPDATE_USER_SUCCESS = 'UPDATE_USER_SUCCESS';

--- a/client/services/actionCreators.jsx
+++ b/client/services/actionCreators.jsx
@@ -90,6 +90,27 @@ function signUpFailure(message) {
   };
 };
 
+exports.logIn = (username, password) => {
+  return (dispatch) => {
+    return network.logIn(username, password)
+      .then((response) => {
+        if(!response.ok){throw response}
+        return response.json()
+          .then((json) => {
+            return dispatch({type:action.LOGIN_SUCCESS, payload:{user:json.user,token:json.token}});
+          })
+      })
+      .catch((err)=>{
+        return dispatch({type:action.LOGIN_FAILURE, payload:err});
+      })
+  }
+};
+
+exports.logOut = () => {
+  //add network logout logic here and in network.jsx
+  return (dispatch)=> dispatch({type:action.LOGOUT});
+};
+
 exports.draftCharacter = ( character ) => {
   //mocked function for now:
   // console.log('state: ', store.getState());

--- a/client/services/network.jsx
+++ b/client/services/network.jsx
@@ -40,28 +40,28 @@ const userRequests = (method, userID, rawParams={}) => {
     .catch((error) => console.log(error))
 };
 
-const signup = ( username, password ) => {
+const signUp = ( username, password ) => {
   let params = makeParams( 'POST', { username, password } );
-
-  // TODO: just return response
   return fetch( url + 'auth/signup', params )
     .catch(( error ) => {
       console.error( error );
     });
 };
 
-const login = ( username, password ) => {
-  let params = makeParams( 'POST', { username, password } );
+const logIn = ( username, password ) => {
+  // will change to post for real server,
+  // POST changes json server, also cannot GET with params
+  let params = makeParams( 'GET', { username, password } );
 
-  return fetch( url + 'auth/login', params )
+  return fetch( url + '/login'/*, params */)
     .catch(( error ) => {
       console.error( error );
     });
 };
 
 export default {
-  signup,
-  login,
+  signUp,
+  logIn,
   getCharacters,
   userRequests,
 };


### PR DESCRIPTION
Had to change the network login request to work with our temp json db. Change back to post with params when node/persistent storage is good to go! 

Currently, we set a token initially on the client side so we don't need to 'login' every time we refresh, but to test it out you can log out and log back in. 

@xbrightmatterx hey Brian! let me know if you have any thought on hooking up the front end up to the back end for auth. Right now I think the plan is to have a simple POST to the /auth/login route with username/password  as params. If successful, the server sends back a token which we store. We then render our app based on whether or user has a token in the store. Anything with cookies or the like? I thought i saw something about jwt tokens. lmk :) 
